### PR TITLE
feat: use GITHUB_ORGS to limit webooks creation

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -10,6 +10,7 @@ GITHUB_CLIENT=xxxxx
 GITHUB_SECRET=xxxxx
 GITHUB_TOKEN=xxxxx
 GITHUB_ADMIN_USERS=ghusername
+GITHUB_ORGS=allowedorg,otherorg
 
 HTTP_PROXY=http://localhost:3128
 HTTPS_PROXY=http://localhost:3128

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ The following are the environment variables you have to configure to run a priva
 - `GITHUB_SECRET`: From your registered application in GitHub.
 - `GITHUB_TOKEN`: Use GitHub token of CLA assistant's user for API calls of not authenticated users. It can be generated here https://github.com/settings/tokens/new. The Only scope required is `public_repo`.
 - `GITHUB_ADMIN_USERS`: (optional, comma-separated) If set, will only allow the specified GitHub users to administer this instance of the app.
+- `GITHUB_ORGS`: (optional, comma-separated) If set, will only allow
+  attaching webooks to repos in the specified GitHub organizations.
 - `MONGODB`: This has to be in form of a mongodb url, e.g. `mongodb://<user>:<password>@<host>:<port>/<dbname>`.
 - `SLACK_URL`: Optional. You can use it in case you would like to get log-notifications posted in your slack chat.
 - `SLACK_TOKEN`: Optional.

--- a/src/config.js
+++ b/src/config.js
@@ -26,6 +26,9 @@ module.exports = {
             admin_users: process.env.GITHUB_ADMIN_USERS ? process.env.GITHUB_ADMIN_USERS.split(/\s*,\s*/) : [],
 
             // required
+            orgs: process.env.GITHUB_ORGS ? process.env.GITHUB_ORGS.split(',') : [],
+
+            // required
             token: process.env.GITHUB_TOKEN,
 
             //temporary, not required

--- a/src/server/services/repo.js
+++ b/src/server/services/repo.js
@@ -3,6 +3,8 @@ const mongoose = require('mongoose')
 const Repo = mongoose.model('Repo')
 const _ = require('lodash')
 
+const config = require('../../config')
+
 //services
 const github = require('../services/github')
 const logger = require('../services/logger')
@@ -273,7 +275,11 @@ class RepoService {
 
         let repoSet = []
         ghRepos.data.forEach((githubRepo) => {
-            if (githubRepo.permissions.push) {
+            if (config.server.github.orgs.length > 0
+                && config.server.github.orgs.indexOf(githubRepo.owner.login) == -1) {
+                return
+            }
+            if (githubRepo.permissions.push ) {
                 repoSet.push({
                     owner: githubRepo.owner.login,
                     repo: githubRepo.name,

--- a/src/server/services/webhook.js
+++ b/src/server/services/webhook.js
@@ -1,4 +1,5 @@
 // module
+const config = require('../../config')
 const github = require('./github')
 const repoService = require('./repo')
 const url = require('./url')
@@ -55,6 +56,12 @@ class WebhookService {
     }
 
     async _createHook(owner, repo, token) {
+        if (config.server.github.orgs.length > 0) {
+            if (config.server.github.orgs.indexOf(owner) == -1) {
+                throw "Not in GITHUB_ORGS: '" + owner + "'"
+            }
+        }
+
         if (!owner || !token) {
             throw 'Owner/org and token are required.'
         }


### PR DESCRIPTION
Add GITHUB_ORGS to allow webooks creation only for the
repos in the specified GitHub organizations.