### PR TITLE
Set NODE_ENV to production by default.

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -14,3 +14,5 @@ GITHUB_ADMIN_USERS=ghusername
 HTTP_PROXY=http://localhost:3128
 HTTPS_PROXY=http://localhost:3128
 NO_PROXY=""
+
+NODE_ENV=production

--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,5 @@ export GITHUB_PASS=
 export HTTP_PROXY=http://localhost:3128
 export HTTPS_PROXY=http://localhost:3128
 export NO_PROXY="https://localhost,http://localhost"
+
+export NODE_ENV=production


### PR DESCRIPTION
Set NODE_ENV to production as it's used to decide, among other, whether
so set Secure on the session cookie..